### PR TITLE
fix $filename path in prepOutput()

### DIFF
--- a/src/OfficeConverter/OfficeConverter.php
+++ b/src/OfficeConverter/OfficeConverter.php
@@ -141,8 +141,9 @@ class OfficeConverter
     {
         $DS = DIRECTORY_SEPARATOR;
         $tmpName = ($this->extension ? str_replace($this->extension, '', $this->basename) : $this->basename . '.').$outputExtension;
-        if (rename($outdir.$DS.$tmpName, $outdir.$DS.$filename)) {
-            return $outdir.$DS.$filename;
+        $fileBaseName = basename($filename);
+        if (rename($outdir.$DS.$tmpName, $outdir.$DS.$fileBaseName)) {
+            return $outdir.$DS.$fileBaseName;
         } elseif (is_file($outdir.$DS.$tmpName)) {
             return $outdir.$DS.$tmpName;
         }


### PR DESCRIPTION
when $filename is passed as absolute path it ends with an exception of wrong path given