### PR TITLE
Bug Fix - File Extension in File Name Errer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Supported conversion formats include:
 * jpeg => pdf
 
 ### Installation
+
 It is recommended to install OfficeConverter through [Composer](http://getcomposer.org/).
 
 Run this command within your project directory

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Supported conversion formats include:
 * jpeg => pdf
 
 ### Installation
+This is a fork, please use the [repo I forked](https://github.com/ncjoes/office-converter)
 
 It is recommended to install OfficeConverter through [Composer](http://getcomposer.org/).
 
@@ -24,6 +25,8 @@ Run this command within your project directory
 ```shell
 composer require ncjoes/office-converter
 ```
+
+Again, this will use the repo I forked, so it is NOT this repo!
 
 ### Dependencies
 In order to use OfficeConverter, you need to install [LibreOffice](http://www.libreoffice.org/).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Supported conversion formats include:
 * jpeg => pdf
 
 ### Installation
-This is a fork, please use the [repo I forked](https://github.com/ncjoes/office-converter)
-
 It is recommended to install OfficeConverter through [Composer](http://getcomposer.org/).
 
 Run this command within your project directory

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Run this command within your project directory
 composer require ncjoes/office-converter
 ```
 
-Again, this will use the repo I forked, so it is NOT this repo!
-
 ### Dependencies
 In order to use OfficeConverter, you need to install [LibreOffice](http://www.libreoffice.org/).
 

--- a/src/OfficeConverter/OfficeConverter.php
+++ b/src/OfficeConverter/OfficeConverter.php
@@ -140,7 +140,7 @@ class OfficeConverter
     protected function prepOutput($outdir, $filename, $outputExtension)
     {
         $DS = DIRECTORY_SEPARATOR;
-        $tmpName = ($this->extension ? str_replace($this->extension, '', $this->basename) : $this->basename . '.').$outputExtension;
+        $tmpName = ($this->extension ? basename($this->basename, $this->extension) : $this->basename . '.').$outputExtension;
         if (rename($outdir.$DS.$tmpName, $outdir.$DS.$filename)) {
             return $outdir.$DS.$filename;
         } elseif (is_file($outdir.$DS.$tmpName)) {


### PR DESCRIPTION
When the file extension is in the filename, it was removed by the `str_replace`. Changing this to the `basename()` function fixes this, as the function specifically removes the extension, and not every instance of the file extension.