### PR TITLE
+ Support for filters & html

### DIFF
--- a/src/OfficeConverter/OfficeConverter.php
+++ b/src/OfficeConverter/OfficeConverter.php
@@ -16,6 +16,8 @@ class OfficeConverter
     private $basename;
     /** @var bool */
     private $prefixExecWithExportHome;
+    /** @var string */
+    private $filter = '';
 
     /**
      * OfficeConverter constructor.
@@ -127,7 +129,18 @@ class OfficeConverter
         $oriFile = escapeshellarg($this->file);
         $outputDirectory = escapeshellarg($outputDirectory);
 
-        return "{$this->bin} --headless --convert-to {$outputExtension} {$oriFile} --outdir {$outputDirectory}";
+        return "{$this->bin} --headless --convert-to {$outputExtension}{$this->filter} {$oriFile} --outdir {$outputDirectory}";
+    }
+
+    /**
+     * @param string $filter
+     *
+     * @return OfficeConverter
+     */
+    public function setFilter ($filter)
+    {
+        $this->filter = ":" . $filter;
+        return $this;
     }
 
     /**
@@ -159,6 +172,7 @@ class OfficeConverter
     {
         $allowedConverter = [
             '' => ['pdf'],
+            'html' => ['pdf', 'docx'],
             'pptx' => ['pdf'],
             'ppt' => ['pdf'],
             'pdf' => ['pdf'],


### PR DESCRIPTION
Add support for filters, so people can enforce them like:
```php
$converter = (new OfficeConverter($path, "/tmp/"))->setFilter("MS Word 2007 XML");
$converter = (new OfficeConverter($path, "/tmp/"))->setFilter('writer_pdf_Export');
```
(https://help.libreoffice.org/latest/en-US/text/shared/guide/convertfilters.html)

And also add support for html to pdf|docx which also works.

Those converting from html should add `<meta http-equiv="Content-Security-Policy" content="sandbox">` on their files, otherwise the conversion is quite bad.
