### PR TITLE
Undo library renaming

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name" : "caiosousaupp/office-converter",
+    "name" : "ncjoes/office-converter",
     "description" : "PHP Wrapper for LibreOffice",
     "keywords" : ["Office","Converter"],
     "license" : "MIT",


### PR DESCRIPTION
The renaming was not supposed to go on the previour PR.