### PR TITLE
Fix #63 "Convertion Failure" error

### DIFF
--- a/src/OfficeConverter/OfficeConverter.php
+++ b/src/OfficeConverter/OfficeConverter.php
@@ -138,12 +138,7 @@ class OfficeConverter
         $outputDirectory = escapeshellarg($outputDirectory);
         $logCmd = $this->logPath ? ">> {$this->logPath}" : '';
 
-        $randomNumber = mt_rand(1, 20);
-
-        // Add the userInstallationDirectory option
-        $userInstallationDirectoryOption = "-env:UserInstallation=file://{$_SERVER['HOME']}/.config/libreoffice-profile{$randomNumber}";
-
-        return "\"$this->bin\" --headless --convert-to {$outputExtension}{$this->filter} $userInstallationDirectoryOption $oriFile --outdir $outputDirectory";
+        return "\"$this->bin\" --headless --convert-to {$outputExtension}{$this->filter} $oriFile --outdir $outputDirectory";
     }
 
     /**


### PR DESCRIPTION
Fix #63
Hello @ncjoes this PR reverts https://github.com/ncjoes/office-converter/pull/54 which causes errors for some people - as author stated, it shouldn't be merged as-is. Unfortunately relying on $_SERVER['HOME'] causes problems on some configurations (see my https://github.com/ncjoes/office-converter/issues/63#issuecomment-2459439112). I think it would be better to revert it to make this library work again without errors.

May I ask you @ncjoes to merge this and release v1.0.8? Anyone who struggles with parallel execution problems (@caiosousaupp @trogau @rabol) could stick to v1.0.7 until some more reliable solution arrives. I don't want to make empty promises, but when I find some time I'll try to look at it.
Thank you!